### PR TITLE
added query param to match only non-pinned tab

### DIFF
--- a/tabvention.js
+++ b/tabvention.js
@@ -32,7 +32,7 @@ function fileAwayDemTabs(newTab)
 
 		console.log(moment().format('MMMM Do, YYYY'));
 
-		chrome.tabs.query({}, function(tabs){
+		chrome.tabs.query({pinned : false}, function(tabs){
 			var tabCount = tabs.length;
 
 			console.log("tabCount: " + tabCount);


### PR DESCRIPTION
I added a `{pinned : false}` param to the query function that will match only non pinned tab.

ref : https://developer.chrome.com/extensions/tabs#method-query

This way an "important" tab (mail,news,...) can be pinned and will not be deleted.
